### PR TITLE
Fix. Pass prefix= and suffix=. arguments to label_number_xx. Closes #14.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.Rproj.user
+.Rproj.user/
 .Rhistory
 .Rdata
 .httr-oauth

--- a/R/label-ch.R
+++ b/R/label-ch.R
@@ -37,6 +37,7 @@ number_ch <- function(x, accuracy = 1, scale = 1,
                       trim = TRUE, ...) {
   label_number_ch(
     accuracy = accuracy, scale = scale,
+    prefix = prefix, suffix = suffix,
     big.mark = big.mark, decimal.mark = decimal.mark,
     trim = trim,
     ...

--- a/R/label-de.R
+++ b/R/label-de.R
@@ -52,6 +52,7 @@ number_de <- function(x, accuracy = 1, scale = 1,
                       trim = TRUE, ...) {
   label_number_de(
     accuracy = accuracy, scale = scale,
+    prefix = prefix, suffix = suffix,
     big.mark = big.mark, decimal.mark = decimal.mark,
     trim = trim,
     ...

--- a/R/label-us.R
+++ b/R/label-us.R
@@ -37,6 +37,7 @@ number_us <- function(x, accuracy = 1, scale = 1,
                       trim = TRUE, ...) {
   label_number_us(
     accuracy = accuracy, scale = scale,
+    prefix = prefix, suffix = suffix,
     big.mark = big.mark, decimal.mark = decimal.mark,
     trim = trim,
     ...

--- a/tests/testthat/test-label-ch.R
+++ b/tests/testthat/test-label-ch.R
@@ -39,3 +39,11 @@ test_that("uses a ’ as big.mark and a . as decimal mark", {
   expect_equal(label_percent_ch()(.243), "24%")
   expect_equal(label_percent_ch(accuracy = .1)(.243), "24.3%")
 })
+
+test_that("number_ch adds a suffix and a prefix", {
+  value <- 100
+  expect_equal(
+    number_ch(value, scale = 1, suffix = "%", prefix = "%"),
+    c("%100%")
+  )
+})

--- a/tests/testthat/test-label-de.R
+++ b/tests/testthat/test-label-de.R
@@ -39,3 +39,11 @@ test_that("uses a . as big.mark and a , as decimal mark", {
   expect_equal(label_percent_de()(.243), "24\u00a0%")
   expect_equal(label_percent_de(accuracy = .1)(.243), "24,3\u00a0%")
 })
+
+test_that("number_de adds a suffix and a prefix", {
+  value <- 100
+  expect_equal(
+    number_de(value, scale = 1, suffix = "%", prefix = "%"),
+    c("%100%")
+  )
+})

--- a/tests/testthat/test-label-us.R
+++ b/tests/testthat/test-label-us.R
@@ -39,3 +39,11 @@ test_that("uses a ’ as big.mark and a . as decimal mark", {
   expect_equal(label_percent_us()(.243), "24%")
   expect_equal(label_percent_us(accuracy = .1)(.243), "24.3%")
 })
+
+test_that("number_us adds a suffix and a prefix", {
+  value <- 100
+  expect_equal(
+    number_us(value, scale = 1, suffix = "%", prefix = "%"),
+    c("%100%")
+  )
+})


### PR DESCRIPTION
``` r
countryscales::number_us(c(1, 2, 3), suffix = " %")
#> [1] "1 %" "2 %" "3 %"
```